### PR TITLE
Add support for various LV2 features (preset, worker, atom-ports)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,674 @@
-This program is free software; you can redistribute it and/or modify
-it under the terms of version 3 of the GNU General Public License as
-published by the Free Software Foundation
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-This program is distributed in the hope that it will be useful, 
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/lv2file.c
+++ b/lv2file.c
@@ -131,14 +131,14 @@ void list_names(LilvWorld* lilvworld, const LilvPlugins* plugins, const char* pl
 	for(uint32_t port=0; port<numports; port++) {
 		const LilvPort* p=lilv_plugin_get_port_by_index(plugin,port);
 		if(lilv_port_is_a(plugin,p,input_class) && lilv_port_is_a(plugin,p,audio_class)) {
-			printf("%s: %s\n",lilv_node_as_string(lilv_port_get_symbol(plugin,p)),lilv_node_as_string(lilv_port_get_name(plugin,p))); 			
+			printf("%s: %s\n",lilv_node_as_string(lilv_port_get_symbol(plugin,p)),lilv_node_as_string(lilv_port_get_name(plugin,p)));
 		}
 	}
 	printf("==Control Ports==\n");
 	for(uint32_t port=0; port<numports; port++) {
 		const LilvPort* p=lilv_plugin_get_port_by_index(plugin,port);
 		if(lilv_port_is_a(plugin,p,input_class) && lilv_port_is_a(plugin,p,control_class)) {
-			printf("%s: %s\n",lilv_node_as_string(lilv_port_get_symbol(plugin,p)),lilv_node_as_string(lilv_port_get_name(plugin,p))); 			
+			printf("%s: %s\n",lilv_node_as_string(lilv_port_get_symbol(plugin,p)),lilv_node_as_string(lilv_port_get_name(plugin,p)));
 		}
 	}
 	lilv_node_free(audio_class);
@@ -164,7 +164,7 @@ void list_names(LilvWorld* lilvworld, const LilvPlugins* plugins, const char* pl
 }
 
 #define INITIALIZE_CLIPPED()
-#define CHECK_CLIPPED() 
+#define CHECK_CLIPPED()
 
 void process_no_check_clipping DEFINE_PROCESS
 
@@ -193,7 +193,7 @@ int main(int argc, char** argv) {
 		goto cleanup_listtable;
 	}
 	lilv_world_load_all(lilvworld);
-	const LilvPlugins* plugins=lilv_world_get_all_plugins(lilvworld); 	
+	const LilvPlugins* plugins=lilv_world_get_all_plugins(lilvworld);
 
 	if(!arg_parse(argc,argv,listtable)) {
 		list_plugins(plugins);
@@ -283,7 +283,7 @@ int main(int argc, char** argv) {
 
 		bool portsproblem=false;
 		for(uint32_t i=0; i<numports; i++) {
-			const LilvPort* porti=lilv_plugin_get_port_by_index(plugin,i);	
+			const LilvPort* porti=lilv_plugin_get_port_by_index(plugin,i);
 			if(lilv_port_is_a(plugin,porti,audio_class)) {
 				if(lilv_port_is_a(plugin,porti,input_class)) {
 					inindices[numin++]=i;
@@ -306,7 +306,7 @@ int main(int argc, char** argv) {
 			} else if(!lilv_port_has_property(plugin,porti,optional)) {
 				fprintf(stderr,"Error!  Unable to handle a required port \n");
 				portsproblem=true;
-			} 
+			}
 		}
 
 		lilv_node_free(input_class);
@@ -337,7 +337,7 @@ int main(int argc, char** argv) {
 						char* nextcomma=strchr(connectionlist,',');
 						char* nextcolon;
 						if(nextcomma) {
-							nextcolon=memchr(connectionlist,':',nextcomma-connectionlist);	
+							nextcolon=memchr(connectionlist,':',nextcomma-connectionlist);
 						} else {
 							nextcolon=strchr(connectionlist,':');
 						}
@@ -387,11 +387,11 @@ int main(int argc, char** argv) {
 						if(channel<0|| ((unsigned)channel)>=numchannels) {
 							fprintf(stderr, "Input sound file does not have channel %u.  It has %u channels.\n",channel+1,numchannels);
 							goto cleanup_outfile;
-						}						
+						}
 
 						char* nextcomma=strchr(connectionlist,',');
 						if(nextcomma) {
-							*nextcomma=0;						
+							*nextcomma=0;
 						}
 						char* nextcolon=strchr(connectionlist,':');
 						//Will not be nill otherwise it would have been caught when counting plugin instances
@@ -443,7 +443,7 @@ int main(int argc, char** argv) {
 						for(unsigned int i=0; i<numchannels; i++) {
 							connections[i][0][i]=true;
 						}
-					} 
+					}
 				}else if(numchannels>numin) {
 					printf("Note: Extra channels ignored when mapping channels to plugin ports\n");
 					for(unsigned int i=0; i<numin; i++) {
@@ -456,7 +456,7 @@ int main(int argc, char** argv) {
 			}
 			for(unsigned int i=0; i<numplugins; i++) {
 				instances[i]=lilv_plugin_instantiate (plugin, formatinfo.samplerate , NULL);
-				lilv_instance_activate(instances[i]); 
+				lilv_instance_activate(instances[i]);
 			}
 			{
 				float pluginbuffers[numplugins][numin][blocksize];
@@ -559,8 +559,7 @@ int main(int argc, char** argv) {
 	cleanup_listnamestable:
 		arg_freetable(listnamestable,sizeof(listnamestable)/sizeof(listnamestable[0]));
 	cleanup_lilvworld:
-		lilv_world_free(lilvworld);  
+		lilv_world_free(lilvworld);
 	cleanup_listtable:
 		arg_freetable(listtable,sizeof(listtable)/sizeof(listtable[0]));
-
 }

--- a/lv2file.c
+++ b/lv2file.c
@@ -1,3 +1,21 @@
+/* Apply an LV2 Audio Plugin to an Audio File
+ *
+ * Copyright (C) 2011-2014 Jeremy Salwen <jeremysalwen@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <sndfile.h>

--- a/lv2file.c
+++ b/lv2file.c
@@ -32,6 +32,8 @@
 #include "lv2/lv2plug.in/ns/ext/atom/atom.h"
 #include "lv2/lv2plug.in/ns/ext/uri-map/uri-map.h"
 #include "lv2/lv2plug.in/ns/ext/urid/urid.h"
+#include "lv2/lv2plug.in/ns/ext/buf-size/buf-size.h"
+#include "lv2/lv2plug.in/ns/ext/options/options.h"
 
 static const size_t atom_capacity = 32768;
 
@@ -509,16 +511,31 @@ int main(int argc, char** argv) {
 				}
 			}
 
+			LV2_URID atom_Int = uri_to_id(NULL, LV2_ATOM__Int);
+			LV2_Options_Option options[] = {
+				{ LV2_OPTIONS_INSTANCE, 0, uri_to_id(NULL, LV2_BUF_SIZE__minBlockLength),
+					sizeof(int32_t), atom_Int, &blocksize },
+				{ LV2_OPTIONS_INSTANCE, 0, uri_to_id(NULL, LV2_BUF_SIZE__maxBlockLength),
+					sizeof(int32_t), atom_Int, &blocksize },
+				{ LV2_OPTIONS_INSTANCE, 0, uri_to_id(NULL, LV2_BUF_SIZE__sequenceSize),
+					sizeof(int32_t), atom_Int, &atom_capacity },
+				{ LV2_OPTIONS_INSTANCE, 0, uri_to_id(NULL, "http://lv2plug.in/ns/ext/buf-size#nominalBlockLength"),
+					sizeof(int32_t), atom_Int, &blocksize },
+				{ LV2_OPTIONS_INSTANCE, 0, 0, 0, 0, NULL }
+			};
 
 			LV2_URID_Map uri_map               = { NULL, &uri_to_id };
 			const LV2_Feature map_feature      = { LV2_URID__map, &uri_map};
 			const LV2_Feature unmap_feature    = { LV2_URID__unmap, NULL };
+			const LV2_Feature options_feature  = { LV2_OPTIONS__options, options};
+
 			for(unsigned int i=0; i<numplugins; i++) {
 
-				int n_features = 2;
+				int n_features = 3;
 				const LV2_Feature* features[5];
 				features[0] = &map_feature;
 				features[1] = &unmap_feature;
+				features[2] = &options_feature;
 
 				features[n_features] = NULL;
 				instances[i] = lilv_plugin_instantiate (plugin, formatinfo.samplerate, features);

--- a/lv2file.c
+++ b/lv2file.c
@@ -305,7 +305,7 @@ int main(int argc, char** argv) {
 	struct arg_file* outfile = arg_file1("o", NULL,"output", "Output sound file");
 	struct arg_rex* controls = arg_rexn("p", "parameters","(\\w+:\\w+,?)*","<controlport>:<float>",0,200,REG_EXTENDED, "Pass a value to a plugin control port.");
 	pluginname = arg_str1(NULL,NULL,"plugin","The LV2 URI of the plugin");
-	struct arg_int* blksize = arg_int0("b","blocksize","<int>","Chunk size in which the sound is processed.  This is frames, not samples.");
+	struct arg_int* blksize = arg_int0("b","blocksize","<int>","Chunk size in which the sound is processed. This is frames, not samples.");
 	struct arg_lit* mono = arg_lit0("m","mono","Mix all of the channels together before processing.");
 	struct arg_lit* ignore_clipping = arg_lit0(NULL,"ignore-clipping", "Do not check for clipping.  This option is slightly faster");
 	blksize->ival[0]=512;
@@ -713,7 +713,7 @@ int main(int argc, char** argv) {
 		}
 		cleanup_outfile:
 			if(sf_close  (outsndfile)) {
-				fprintf(stderr,"Error closing input file!\n");
+				fprintf(stderr,"Error closing output file!\n");
 			}
 	}
 

--- a/lv2file.c
+++ b/lv2file.c
@@ -19,22 +19,22 @@
 
 #define _GNU_SOURCE // strdup
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <sndfile.h>
 #include <argtable2.h>
 #include <lilv/lilv.h>
-#include <string.h>
 #include <math.h>
 #include <regex.h>
+#include <sndfile.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "lv2.h"
 #include "lv2/lv2plug.in/ns/ext/atom/atom.h"
+#include "lv2/lv2plug.in/ns/ext/buf-size/buf-size.h"
+#include "lv2/lv2plug.in/ns/ext/options/options.h"
 #include "lv2/lv2plug.in/ns/ext/presets/presets.h"
 #include "lv2/lv2plug.in/ns/ext/uri-map/uri-map.h"
 #include "lv2/lv2plug.in/ns/ext/urid/urid.h"
-#include "lv2/lv2plug.in/ns/ext/buf-size/buf-size.h"
-#include "lv2/lv2plug.in/ns/ext/options/options.h"
 #include "lv2/lv2plug.in/ns/ext/worker/worker.h"
 
 static const size_t atom_capacity = 32768;
@@ -43,26 +43,30 @@ static const size_t atom_capacity = 32768;
  * LV2 URI MAP
  */
 
-static char **urimap = NULL;
+static char**   urimap     = NULL;
 static uint32_t urimap_len = 0;
 
-static uint32_t uri_to_id(LV2_URI_Map_Callback_Data unused, const char* uri) {
-  (void) unused;
-  for (uint32_t i = 0; i < urimap_len; ++i) {
-    if (!strcmp(urimap[i], uri)) {
-      return i + 1;
-    }
-  }
-  urimap = (char**) realloc(urimap, (urimap_len + 1) * sizeof(char*));
-  urimap[urimap_len] = strdup(uri);
-  return ++urimap_len;
+static uint32_t
+uri_to_id (LV2_URI_Map_Callback_Data unused, const char* uri)
+{
+	(void)unused;
+	for (uint32_t i = 0; i < urimap_len; ++i) {
+		if (!strcmp (urimap[i], uri)) {
+			return i + 1;
+		}
+	}
+	urimap             = (char**)realloc (urimap, (urimap_len + 1) * sizeof (char*));
+	urimap[urimap_len] = strdup (uri);
+	return ++urimap_len;
 }
 
-static void free_uri_map() {
-  for (uint32_t i=0; i < urimap_len; ++i) {
-    free(urimap[i]);
-  }
-  free(urimap);
+static void
+free_uri_map ()
+{
+	for (uint32_t i = 0; i < urimap_len; ++i) {
+		free (urimap[i]);
+	}
+	free (urimap);
 }
 
 /* ****************************************************************************
@@ -71,22 +75,22 @@ static void free_uri_map() {
 static LV2_Worker_Interface* worker_iface = NULL;
 
 static LV2_Worker_Status
-lv2_worker_respond(LV2_Worker_Respond_Handle handle,
-                   uint32_t                  size,
-                   const void*               data)
+lv2_worker_respond (LV2_Worker_Respond_Handle handle,
+                    uint32_t                  size,
+                    const void*               data)
 {
-	worker_iface->work_response(handle, size, data);
+	worker_iface->work_response (handle, size, data);
 	return LV2_WORKER_SUCCESS;
 }
 
 static LV2_Worker_Status
-lv2_worker_schedule(LV2_Worker_Schedule_Handle handle,
-                    uint32_t                   size,
-                    const void*                data)
+lv2_worker_schedule (LV2_Worker_Schedule_Handle handle,
+                     uint32_t                   size,
+                     const void*                data)
 {
 	printf ("lv2_worker_schedule..\n");
 	/* all processing is non-realtime, scheduled work can be executed immediately */
-	worker_iface->work(handle, lv2_worker_respond, handle, size, data);
+	worker_iface->work (handle, lv2_worker_respond, handle, size, data);
 	return LV2_WORKER_SUCCESS;
 }
 
@@ -100,20 +104,20 @@ struct statehelper {
 };
 
 static void
-set_port_value(const char* port_symbol,
-               void*       user_data,
-               const void* value,
-               uint32_t    size,
-               uint32_t    type)
+set_port_value (const char* port_symbol,
+                void*       user_data,
+                const void* value,
+                uint32_t    size,
+                uint32_t    type)
 {
-	if (type != 0 && type != uri_to_id(NULL, "http://lv2plug.in/ns/ext/atom#Float")) {
+	if (type != 0 && type != uri_to_id (NULL, "http://lv2plug.in/ns/ext/atom#Float")) {
 		return;
 	}
-	(void) size; // unused
+	(void)size; // unused
 	float val = *(const float*)value;
 	//printf ("STATE set %s to %f (t: %d)\n", port_symbol, val, type);
-	struct statehelper* sh = (struct statehelper*) user_data;
-	for(uint32_t port = 0; port < sh->numports; ++port) {
+	struct statehelper* sh = (struct statehelper*)user_data;
+	for (uint32_t port = 0; port < sh->numports; ++port) {
 		const char* symbol = lilv_node_as_string (lilv_port_get_symbol (sh->plugin, lilv_plugin_get_port_by_index (sh->plugin, port)));
 		if (!strcmp (symbol, port_symbol)) {
 			//printf ("STATE actually set %d to %f\n", port, val);
@@ -124,142 +128,161 @@ set_port_value(const char* port_symbol,
 }
 
 //From lv2_simple_jack_host in slv2 (GPL code)
-void list_plugins(const LilvPlugins* list)
+void
+list_plugins (const LilvPlugins* list)
 {
-	int j=1;
-	LILV_FOREACH(plugins,i,list) {
-		const LilvPlugin* p=lilv_plugins_get(list,i);
-		printf("%d\t%s\n", j++, lilv_node_as_uri(lilv_plugin_get_uri(p)));
+	int j = 1;
+	LILV_FOREACH (plugins, i, list)
+	{
+		const LilvPlugin* p = lilv_plugins_get (list, i);
+		printf ("%d\t%s\n", j++, lilv_node_as_uri (lilv_plugin_get_uri (p)));
 	}
 }
 
-const LilvPlugin* plugins_get_at(const LilvPlugins* plugins, unsigned int n) {
-	unsigned int j=0;
-	LILV_FOREACH(plugins,i,plugins) {
-		if(j==n) {
-			return lilv_plugins_get(plugins,i);
+const LilvPlugin*
+plugins_get_at (const LilvPlugins* plugins, unsigned int n)
+{
+	unsigned int j = 0;
+	LILV_FOREACH (plugins, i, plugins)
+	{
+		if (j == n) {
+			return lilv_plugins_get (plugins, i);
 		}
 		j++;
 	}
 	return NULL;
 }
 
-const LilvPlugin* getplugin(const char* name, const LilvPlugins* plugins, LilvWorld* lilvworld) {
-	int index=atoi(name);
-	if(index!=0) {
-		return plugins_get_at(plugins,index-1);
+const LilvPlugin*
+getplugin (const char* name, const LilvPlugins* plugins, LilvWorld* lilvworld)
+{
+	int index = atoi (name);
+	if (index != 0) {
+		return plugins_get_at (plugins, index - 1);
 	} else {
-		LilvNode* plugin_uri = lilv_new_uri(lilvworld, name);
-		if(!plugin_uri) {
+		LilvNode* plugin_uri = lilv_new_uri (lilvworld, name);
+		if (!plugin_uri) {
 			return NULL;
 		}
-		const LilvPlugin* plugin = lilv_plugins_get_by_uri(plugins, plugin_uri);
-		lilv_node_free(plugin_uri);
+		const LilvPlugin* plugin = lilv_plugins_get_by_uri (plugins, plugin_uri);
+		lilv_node_free (plugin_uri);
 		return plugin;
 	}
 }
 
-unsigned int popcount(bool* connections, unsigned int numchannels) {
-	unsigned int result=0;
-	for(unsigned int i=0; i<numchannels; i++) {
-		result+=connections[i];
+unsigned int
+popcount (bool* connections, unsigned int numchannels)
+{
+	unsigned int result = 0;
+	for (unsigned int i = 0; i < numchannels; i++) {
+		result += connections[i];
 	}
 	return result;
 }
 
-void mix(float* buffer, sf_count_t framesread,unsigned int numchannels, unsigned int numplugins, unsigned int numin, bool connections[numplugins][numin][numchannels], unsigned int blocksize, float pluginbuffers[numplugins][numin][blocksize]) {
-	for(unsigned int i=0; i<framesread; i++) {
-		for(unsigned int plugnum=0; plugnum<numplugins; plugnum++) {
-			for(unsigned int port=0; port<numin; port++) {
-				unsigned int nummixed=0;
-				pluginbuffers[plugnum][port][i]=0;
-				for(unsigned int channel=0; channel<numchannels; channel++) {
-					if(connections[plugnum][port][channel]) {
+void
+mix (float* buffer, sf_count_t framesread, unsigned int numchannels, unsigned int numplugins, unsigned int numin, bool connections[numplugins][numin][numchannels], unsigned int blocksize, float pluginbuffers[numplugins][numin][blocksize])
+{
+	for (unsigned int i = 0; i < framesread; i++) {
+		for (unsigned int plugnum = 0; plugnum < numplugins; plugnum++) {
+			for (unsigned int port = 0; port < numin; port++) {
+				unsigned int nummixed           = 0;
+				pluginbuffers[plugnum][port][i] = 0;
+				for (unsigned int channel = 0; channel < numchannels; channel++) {
+					if (connections[plugnum][port][channel]) {
 						nummixed++;
-						pluginbuffers[plugnum][port][i]+=buffer[i*numchannels+channel];
+						pluginbuffers[plugnum][port][i] += buffer[i * numchannels + channel];
 					}
 				}
-				if(nummixed) {
-					pluginbuffers[plugnum][port][i]/=nummixed;
+				if (nummixed) {
+					pluginbuffers[plugnum][port][i] /= nummixed;
 				}
 			}
 		}
 	}
 }
 
-void interleaveoutput(sf_count_t numread, unsigned int numplugins, unsigned int numout, unsigned int blocksize, float outputbuffers[numplugins][numout][blocksize], float sndfilebuffer[numout * blocksize]) {
-	for(unsigned int plugin=0; plugin<numplugins; plugin++) {
-		for(unsigned int port=0; port<numout; port++) {
-			for(unsigned int i=0; i<numread; i++) {
-				sndfilebuffer[plugin*numout*blocksize+i*numout+port]=outputbuffers[plugin][port][i];
+void
+interleaveoutput (sf_count_t numread, unsigned int numplugins, unsigned int numout, unsigned int blocksize, float outputbuffers[numplugins][numout][blocksize], float sndfilebuffer[numout * blocksize])
+{
+	for (unsigned int plugin = 0; plugin < numplugins; plugin++) {
+		for (unsigned int port = 0; port < numout; port++) {
+			for (unsigned int i = 0; i < numread; i++) {
+				sndfilebuffer[plugin * numout * blocksize + i * numout + port] = outputbuffers[plugin][port][i];
 			}
 		}
 	}
 }
 
-float getstartingvalue(float dflt,float min, float max) {
-	if(!isnan(dflt)) {
+float
+getstartingvalue (float dflt, float min, float max)
+{
+	if (!isnan (dflt)) {
 		return dflt;
 	} else {
-		if(isnan(min)) {
-			if(isnan(max)) {
+		if (isnan (min)) {
+			if (isnan (max)) {
 				return 0;
 			} else {
-				return fmin(max,0);
+				return fmin (max, 0);
 			}
 		} else {
-			if(isnan(max)) {
-				return fmax(min,0);
+			if (isnan (max)) {
+				return fmax (min, 0);
 			} else {
-				return (min+max)/2;
+				return (min + max) / 2;
 			}
 		}
 	}
 }
 
-inline char clipOutput(unsigned long size, float* buffer) {
-	char clipped=0;
-	for(unsigned int i=0; i<size; i++) {
-		if(buffer[i]>1) {
-			clipped=true;
-			buffer[i]=1;
+inline char
+clipOutput (unsigned long size, float* buffer)
+{
+	char clipped = 0;
+	for (unsigned int i = 0; i < size; i++) {
+		if (buffer[i] > 1) {
+			clipped   = true;
+			buffer[i] = 1;
 		}
 	}
-	for(unsigned int i=0; i<size; i++) {
-		if(buffer[i]<-1) {
-			clipped=true;
-			buffer[i]=-1;
+	for (unsigned int i = 0; i < size; i++) {
+		if (buffer[i] < -1) {
+			clipped   = true;
+			buffer[i] = -1;
 		}
 	}
 	return clipped;
 }
-void list_names(LilvWorld* lilvworld, const LilvPlugins* plugins, const char* plugin_name) {
-	const LilvPlugin* plugin=getplugin(plugin_name,plugins,lilvworld);
-	if(!plugin) {
-		fprintf(stderr,"No such plugin %s\n",plugin_name);
+void
+list_names (LilvWorld* lilvworld, const LilvPlugins* plugins, const char* plugin_name)
+{
+	const LilvPlugin* plugin = getplugin (plugin_name, plugins, lilvworld);
+	if (!plugin) {
+		fprintf (stderr, "No such plugin %s\n", plugin_name);
 		return;
 	}
-	LilvNode* input_class = lilv_new_uri(lilvworld, LILV_URI_INPUT_PORT);
-	LilvNode* control_class = lilv_new_uri(lilvworld, LILV_URI_CONTROL_PORT);
-	LilvNode* audio_class = lilv_new_uri(lilvworld, LILV_URI_AUDIO_PORT);
-	uint32_t numports=lilv_plugin_get_num_ports(plugin);
-	printf("==Audio Ports==\n");
-	for(uint32_t port=0; port<numports; port++) {
-		const LilvPort* p=lilv_plugin_get_port_by_index(plugin,port);
-		if(lilv_port_is_a(plugin,p,input_class) && lilv_port_is_a(plugin,p,audio_class)) {
-			printf("%s: %s\n",lilv_node_as_string(lilv_port_get_symbol(plugin,p)),lilv_node_as_string(lilv_port_get_name(plugin,p)));
+	LilvNode* input_class   = lilv_new_uri (lilvworld, LILV_URI_INPUT_PORT);
+	LilvNode* control_class = lilv_new_uri (lilvworld, LILV_URI_CONTROL_PORT);
+	LilvNode* audio_class   = lilv_new_uri (lilvworld, LILV_URI_AUDIO_PORT);
+	uint32_t  numports      = lilv_plugin_get_num_ports (plugin);
+	printf ("==Audio Ports==\n");
+	for (uint32_t port = 0; port < numports; port++) {
+		const LilvPort* p = lilv_plugin_get_port_by_index (plugin, port);
+		if (lilv_port_is_a (plugin, p, input_class) && lilv_port_is_a (plugin, p, audio_class)) {
+			printf ("%s: %s\n", lilv_node_as_string (lilv_port_get_symbol (plugin, p)), lilv_node_as_string (lilv_port_get_name (plugin, p)));
 		}
 	}
-	printf("==Control Ports==\n");
-	for(uint32_t port=0; port<numports; port++) {
-		const LilvPort* p=lilv_plugin_get_port_by_index(plugin,port);
-		if(lilv_port_is_a(plugin,p,input_class) && lilv_port_is_a(plugin,p,control_class)) {
-			printf("%s: %s\n",lilv_node_as_string(lilv_port_get_symbol(plugin,p)),lilv_node_as_string(lilv_port_get_name(plugin,p)));
+	printf ("==Control Ports==\n");
+	for (uint32_t port = 0; port < numports; port++) {
+		const LilvPort* p = lilv_plugin_get_port_by_index (plugin, port);
+		if (lilv_port_is_a (plugin, p, input_class) && lilv_port_is_a (plugin, p, control_class)) {
+			printf ("%s: %s\n", lilv_node_as_string (lilv_port_get_symbol (plugin, p)), lilv_node_as_string (lilv_port_get_name (plugin, p)));
 		}
 	}
-	lilv_node_free(audio_class);
-	lilv_node_free(input_class);
-	lilv_node_free(control_class);
+	lilv_node_free (audio_class);
+	lilv_node_free (input_class);
+	lilv_node_free (control_class);
 }
 
 /* TODO Notes:
@@ -305,7 +328,6 @@ void list_names(LilvWorld* lilvworld, const LilvPlugins* plugins, const char* pl
 }
 /* clang-format on */
 
-
 #define INITIALIZE_CLIPPED()
 #define CHECK_CLIPPED()
 
@@ -324,340 +346,341 @@ if(!clipped && clipOutput (numread * numout, sndfilebuffer)) {                  
       "Try changing parameters of the plugin to lower the output volume, "                     \
       "or if that's not possible, try lowering the volume of the input before processing.\n"); \
 }
-/* clang-format on */
+    /* clang-format on */
 
-void process_check_clipping DEFINE_PROCESS
+    void process_check_clipping DEFINE_PROCESS
 
-int main(int argc, char** argv) {
-	struct arg_lit *listopt = arg_lit1 ("l", "list", "Lists all available LV2 plugins");
-	struct arg_end *listend = arg_end(20);
-	void *listtable[] = {listopt, listend};
+    int
+    main (int argc, char** argv)
+{
+	struct arg_lit* listopt     = arg_lit1 ("l", "list", "Lists all available LV2 plugins");
+	struct arg_end* listend     = arg_end (20);
+	void*           listtable[] = { listopt, listend };
 
 	bool list_presets_only = false;
 
-	if (arg_nullcheck(listtable) != 0) {
-		printf("Error: insufficient memory\n");
+	if (arg_nullcheck (listtable) != 0) {
+		printf ("Error: insufficient memory\n");
 		goto cleanup_listtable;
 	}
 
-	LilvWorld* lilvworld=lilv_world_new();
-	if(lilvworld==NULL) {
+	LilvWorld* lilvworld = lilv_world_new ();
+	if (lilvworld == NULL) {
 		goto cleanup_listtable;
 	}
-	lilv_world_load_all(lilvworld);
-	const LilvPlugins* plugins=lilv_world_get_all_plugins(lilvworld);
+	lilv_world_load_all (lilvworld);
+	const LilvPlugins* plugins = lilv_world_get_all_plugins (lilvworld);
 
-	if(!arg_parse(argc,argv,listtable)) {
-		list_plugins(plugins);
+	if (!arg_parse (argc, argv, listtable)) {
+		list_plugins (plugins);
 		goto cleanup_lilvworld;
 	}
 
-
-	struct arg_lit *preslistopt = arg_lit1 ("L", "list-presets", "Lists presets for given plugin LV2 plugins");
-	struct arg_lit *portnames = arg_lit1("n","nameports","List the names of the input ports of a given plugin");
-	struct arg_str *pluginname = arg_str1(NULL,NULL,"plugin",NULL);
-	struct arg_end *nameend=arg_end(20);
-	void *listnamestable[]={portnames,pluginname,nameend};
-	if (arg_nullcheck(listnamestable) != 0) {
-		fprintf(stderr, "Error: insufficient memory\n");
+	struct arg_lit* preslistopt      = arg_lit1 ("L", "list-presets", "Lists presets for given plugin LV2 plugins");
+	struct arg_lit* portnames        = arg_lit1 ("n", "nameports", "List the names of the input ports of a given plugin");
+	struct arg_str* pluginname       = arg_str1 (NULL, NULL, "plugin", NULL);
+	struct arg_end* nameend          = arg_end (20);
+	void*           listnamestable[] = { portnames, pluginname, nameend };
+	if (arg_nullcheck (listnamestable) != 0) {
+		fprintf (stderr, "Error: insufficient memory\n");
 		goto cleanup_listnamestable;
 	}
-	if(!arg_parse(argc,argv,listnamestable)) {
-		list_names(lilvworld,plugins,pluginname->sval[0]);
-		goto cleanup_listnamestable;
-	}
-
-	void *listpresettable[]={preslistopt,pluginname,nameend};
-	if (arg_nullcheck(listpresettable) != 0) {
-		fprintf(stderr, "Error: insufficient memory\n");
+	if (!arg_parse (argc, argv, listnamestable)) {
+		list_names (lilvworld, plugins, pluginname->sval[0]);
 		goto cleanup_listnamestable;
 	}
 
-	if(!arg_parse(argc,argv,listpresettable)) {
+	void* listpresettable[] = { preslistopt, pluginname, nameend };
+	if (arg_nullcheck (listpresettable) != 0) {
+		fprintf (stderr, "Error: insufficient memory\n");
+		goto cleanup_listnamestable;
+	}
+
+	if (!arg_parse (argc, argv, listpresettable)) {
 		list_presets_only = true;
 	}
 
-	struct arg_rex *connectargs= arg_rexn("c","connect","(\\d+:(\\d+\\.)?\\w+,?)*","<int>:<audioport>",0,200,REG_EXTENDED,"Connect between audio file channels and plugin input channels.");
+	struct arg_rex* connectargs = arg_rexn ("c", "connect", "(\\d+:(\\d+\\.)?\\w+,?)*", "<int>:<audioport>", 0, 200, REG_EXTENDED, "Connect between audio file channels and plugin input channels.");
 
-	struct arg_file* infile = arg_file1("i", NULL,"input", "Input sound file");
-	struct arg_file* outfile = arg_file1("o", NULL,"output", "Output sound file");
-	struct arg_rex* controls = arg_rexn("p", "parameters","(\\w+:\\w+,?)*","<controlport>:<float>",0,200,REG_EXTENDED, "Pass a value to a plugin control port.");
-	pluginname = arg_str1(NULL,NULL,"plugin","The LV2 URI of the plugin");
-	struct arg_int* blksize = arg_int0("b","blocksize","<int>","Chunk size in which the sound is processed. This is frames, not samples.");
-	struct arg_str* presetname = arg_str0("p","preset","<name>","Plugin-preset to load (before applying custom ctrl-port values)");
-	struct arg_lit* mono = arg_lit0("m","mono","Mix all of the channels together before processing.");
-	struct arg_lit* ignore_clipping = arg_lit0(NULL,"ignore-clipping", "Do not check for clipping.  This option is slightly faster");
-	blksize->ival[0]=512;
-	struct arg_end *endarg = arg_end(20);
-	void *argtable[] = {infile, outfile,presetname,controls,connectargs,blksize,mono,ignore_clipping,pluginname, endarg};
-	if (arg_nullcheck(argtable) != 0) {
-		fprintf(stderr,"Error: insufficient memory\n");
+	struct arg_file* infile         = arg_file1 ("i", NULL, "input", "Input sound file");
+	struct arg_file* outfile        = arg_file1 ("o", NULL, "output", "Output sound file");
+	struct arg_rex*  controls       = arg_rexn ("p", "parameters", "(\\w+:\\w+,?)*", "<controlport>:<float>", 0, 200, REG_EXTENDED, "Pass a value to a plugin control port.");
+	pluginname                      = arg_str1 (NULL, NULL, "plugin", "The LV2 URI of the plugin");
+	struct arg_int* blksize         = arg_int0 ("b", "blocksize", "<int>", "Chunk size in which the sound is processed. This is frames, not samples.");
+	struct arg_str* presetname      = arg_str0 ("p", "preset", "<name>", "Plugin-preset to load (before applying custom ctrl-port values)");
+	struct arg_lit* mono            = arg_lit0 ("m", "mono", "Mix all of the channels together before processing.");
+	struct arg_lit* ignore_clipping = arg_lit0 (NULL, "ignore-clipping", "Do not check for clipping.  This option is slightly faster");
+	blksize->ival[0]                = 512;
+	struct arg_end* endarg          = arg_end (20);
+	void*           argtable[]      = { infile, outfile, presetname, controls, connectargs, blksize, mono, ignore_clipping, pluginname, endarg };
+	if (arg_nullcheck (argtable) != 0) {
+		fprintf (stderr, "Error: insufficient memory\n");
 		goto cleanup_argtable;
 	}
-	int nerrors = arg_parse(argc,argv,argtable);
-	if(nerrors && !list_presets_only) {
-		arg_print_errors(stderr,endarg,"lv2file");
-		fprintf(stderr,"usage:\nlv2file\t");
-		arg_print_syntaxv(stderr, listtable,"\n\t");
-		arg_print_syntaxv(stderr, listpresettable,"\n\t");
-		arg_print_syntaxv(stderr, listnamestable,"\n\t");
-		arg_print_syntaxv(stderr, argtable,"\n");
-		arg_print_glossary_gnu(stderr, listtable);
-		arg_print_glossary_gnu(stderr, listnamestable);
-		arg_print_glossary_gnu(stderr, argtable);
+	int nerrors = arg_parse (argc, argv, argtable);
+	if (nerrors && !list_presets_only) {
+		arg_print_errors (stderr, endarg, "lv2file");
+		fprintf (stderr, "usage:\nlv2file\t");
+		arg_print_syntaxv (stderr, listtable, "\n\t");
+		arg_print_syntaxv (stderr, listpresettable, "\n\t");
+		arg_print_syntaxv (stderr, listnamestable, "\n\t");
+		arg_print_syntaxv (stderr, argtable, "\n");
+		arg_print_glossary_gnu (stderr, listtable);
+		arg_print_glossary_gnu (stderr, listnamestable);
+		arg_print_glossary_gnu (stderr, argtable);
 		goto cleanup_argtable;
 	}
 
-	bool mixdown=mono->count;
+	bool mixdown = mono->count;
 
-	const LilvPlugin* plugin=getplugin(pluginname->sval[0],plugins,lilvworld);
-	if(!plugin) {
-		fprintf(stderr,"No such plugin %s\n", pluginname->sval[0]);
+	const LilvPlugin* plugin = getplugin (pluginname->sval[0], plugins, lilvworld);
+	if (!plugin) {
+		fprintf (stderr, "No such plugin %s\n", pluginname->sval[0]);
 		goto cleanup_argtable;
 	}
-	LilvNode* input_class = lilv_new_uri(lilvworld, LILV_URI_INPUT_PORT);
-	LilvNode* output_class = lilv_new_uri(lilvworld, LILV_URI_OUTPUT_PORT);
-	LilvNode* control_class = lilv_new_uri(lilvworld, LILV_URI_CONTROL_PORT);
-	LilvNode* audio_class = lilv_new_uri(lilvworld, LILV_URI_AUDIO_PORT);
-	LilvNode* event_class = lilv_new_uri(lilvworld, LILV_URI_EVENT_PORT);
-	LilvNode* midi_class = lilv_new_uri(lilvworld, LILV_URI_MIDI_EVENT);
-	LilvNode* preset_class = lilv_new_uri(lilvworld, LV2_PRESETS__Preset);
-	LilvNode* optional = lilv_new_uri(lilvworld, LILV_NS_LV2 "connectionOptional");
-	LilvNode* freewheel_port = lilv_new_uri(lilvworld, LV2_CORE__freeWheeling);
-	LilvNode* latency_port = lilv_new_uri(lilvworld, LV2_CORE__reportsLatency);
-	LilvNode* label_pred = lilv_new_uri(lilvworld, LILV_NS_RDFS "label");
-	LilvNode* atom_AtomPort = lilv_new_uri(lilvworld, LV2_ATOM__AtomPort);
-	LilvNode* atom_Sequence = lilv_new_uri(lilvworld, LV2_ATOM__Sequence);
-	LilvNode* worker_schedule = lilv_new_uri(lilvworld, LV2_WORKER__schedule);
-	LilvNode* worker_iface_uri = lilv_new_uri(lilvworld, LV2_WORKER__interface);
+	LilvNode* input_class      = lilv_new_uri (lilvworld, LILV_URI_INPUT_PORT);
+	LilvNode* output_class     = lilv_new_uri (lilvworld, LILV_URI_OUTPUT_PORT);
+	LilvNode* control_class    = lilv_new_uri (lilvworld, LILV_URI_CONTROL_PORT);
+	LilvNode* audio_class      = lilv_new_uri (lilvworld, LILV_URI_AUDIO_PORT);
+	LilvNode* event_class      = lilv_new_uri (lilvworld, LILV_URI_EVENT_PORT);
+	LilvNode* midi_class       = lilv_new_uri (lilvworld, LILV_URI_MIDI_EVENT);
+	LilvNode* preset_class     = lilv_new_uri (lilvworld, LV2_PRESETS__Preset);
+	LilvNode* optional         = lilv_new_uri (lilvworld, LILV_NS_LV2 "connectionOptional");
+	LilvNode* freewheel_port   = lilv_new_uri (lilvworld, LV2_CORE__freeWheeling);
+	LilvNode* latency_port     = lilv_new_uri (lilvworld, LV2_CORE__reportsLatency);
+	LilvNode* label_pred       = lilv_new_uri (lilvworld, LILV_NS_RDFS "label");
+	LilvNode* atom_AtomPort    = lilv_new_uri (lilvworld, LV2_ATOM__AtomPort);
+	LilvNode* atom_Sequence    = lilv_new_uri (lilvworld, LV2_ATOM__Sequence);
+	LilvNode* worker_schedule  = lilv_new_uri (lilvworld, LV2_WORKER__schedule);
+	LilvNode* worker_iface_uri = lilv_new_uri (lilvworld, LV2_WORKER__interface);
 
 	/* get plugin presets */
-	LilvState* state = NULL;
-	LilvNodes* presets = lilv_plugin_get_related(plugin, preset_class);
+	LilvState* state   = NULL;
+	LilvNodes* presets = lilv_plugin_get_related (plugin, preset_class);
 	if (presets) {
-		LILV_FOREACH(nodes, i, presets) {
-			const LilvNode* preset = lilv_nodes_get(presets, i);
-			lilv_world_load_resource(lilvworld, preset);
-			LilvNodes* titles = lilv_world_find_nodes(lilvworld, preset, label_pred, NULL);
+		LILV_FOREACH (nodes, i, presets)
+		{
+			const LilvNode* preset = lilv_nodes_get (presets, i);
+			lilv_world_load_resource (lilvworld, preset);
+			LilvNodes* titles = lilv_world_find_nodes (lilvworld, preset, label_pred, NULL);
 			if (titles) {
-				const char* title = lilv_node_as_string(lilv_nodes_get_first(titles));
+				const char* title = lilv_node_as_string (lilv_nodes_get_first (titles));
 				if (list_presets_only) {
-					printf("Preset: %s\n", title);
+					printf ("Preset: %s\n", title);
 				} else if (presetname->count > 0 && !strcmp (presetname->sval[0], title)) {
 					LV2_URID_Map uri_map = { NULL, &uri_to_id };
-					state = lilv_state_new_from_world(lilvworld, &uri_map, preset);
-					lilv_nodes_free(titles);
+					state                = lilv_state_new_from_world (lilvworld, &uri_map, preset);
+					lilv_nodes_free (titles);
 					break;
 				}
-				lilv_nodes_free(titles);
+				lilv_nodes_free (titles);
 			}
 		}
 	}
-	lilv_nodes_free(presets);
+	lilv_nodes_free (presets);
 	if (list_presets_only) {
 		goto cleanup_lilvnodes;
 	}
 
 	if (presetname->count > 0 && !state) {
-		fprintf(stderr,"Preset '%s' was not found.\n",presetname->sval[0]);
+		fprintf (stderr, "Preset '%s' was not found.\n", presetname->sval[0]);
 	}
 
 	SF_INFO formatinfo;
-	formatinfo.format=0;
-	SNDFILE* insndfile=sf_open(*(infile->filename), SFM_READ, &formatinfo);
-	int sndfileerr=sf_error(insndfile) ;
-	if(sndfileerr) {
-		fprintf(stderr,"Error reading input file: %s\n",sf_error_number(sndfileerr));
+	formatinfo.format   = 0;
+	SNDFILE* insndfile  = sf_open (*(infile->filename), SFM_READ, &formatinfo);
+	int      sndfileerr = sf_error (insndfile);
+	if (sndfileerr) {
+		fprintf (stderr, "Error reading input file: %s\n", sf_error_number (sndfileerr));
 		goto cleanup_sndfile;
 	}
 
-	unsigned int numchannels=formatinfo.channels;
-	unsigned int blocksize=blksize->ival[0];
-
+	unsigned int numchannels = formatinfo.channels;
+	unsigned int blocksize   = blksize->ival[0];
 
 	{
-		uint32_t numports=lilv_plugin_get_num_ports(plugin);
-		unsigned int numout=0;
-		uint32_t outindices[numports];
-		unsigned int numin=0;
-		uint32_t inindices[numports];
-		unsigned int numcontrol=0;
-		uint32_t controlindices[numports];
-		unsigned int numcontrolout=0;
-		uint32_t controloutindices[numports];
+		uint32_t     numports = lilv_plugin_get_num_ports (plugin);
+		unsigned int numout   = 0;
+		uint32_t     outindices[numports];
+		unsigned int numin = 0;
+		uint32_t     inindices[numports];
+		unsigned int numcontrol = 0;
+		uint32_t     controlindices[numports];
+		unsigned int numcontrolout = 0;
+		uint32_t     controloutindices[numports];
 
-		bool portsproblem=false;
-		int fwheelportidx = -1;
-		for(uint32_t i=0; i<numports; i++) {
-			const LilvPort* porti=lilv_plugin_get_port_by_index(plugin,i);
-			if(lilv_port_is_a(plugin,porti,audio_class)) {
-				if(lilv_port_is_a(plugin,porti,input_class)) {
-					inindices[numin++]=i;
-				} else if(lilv_port_is_a(plugin,porti,output_class)) {
-					outindices[numout++]=i;
+		bool portsproblem  = false;
+		int  fwheelportidx = -1;
+		for (uint32_t i = 0; i < numports; i++) {
+			const LilvPort* porti = lilv_plugin_get_port_by_index (plugin, i);
+			if (lilv_port_is_a (plugin, porti, audio_class)) {
+				if (lilv_port_is_a (plugin, porti, input_class)) {
+					inindices[numin++] = i;
+				} else if (lilv_port_is_a (plugin, porti, output_class)) {
+					outindices[numout++] = i;
 				} else {
-					fprintf(stderr, "Audio port not input or output\n");
-					portsproblem=true;
+					fprintf (stderr, "Audio port not input or output\n");
+					portsproblem = true;
 				}
-			} else if(lilv_port_is_a(plugin,porti,control_class)) {
+			} else if (lilv_port_is_a (plugin, porti, control_class)) {
 				//We really only care about *input* control ports.
-				if(lilv_port_is_a(plugin,porti,input_class)) {
-					controlindices[numcontrol++]=i;
-					if (lilv_port_has_property(plugin, porti, freewheel_port)) {
+				if (lilv_port_is_a (plugin, porti, input_class)) {
+					controlindices[numcontrol++] = i;
+					if (lilv_port_has_property (plugin, porti, freewheel_port)) {
 						fwheelportidx = i;
 					}
-				} else if(lilv_port_is_a(plugin,porti,output_class)) {
-					if (lilv_port_has_property(plugin, porti, latency_port)) {
+				} else if (lilv_port_is_a (plugin, porti, output_class)) {
+					if (lilv_port_has_property (plugin, porti, latency_port)) {
 						// TODO: remember this port, use its value later (ignore first N output samples)
 					}
-					controloutindices[numcontrolout++]=i;
+					controloutindices[numcontrolout++] = i;
 				} else {
-					fprintf(stderr, "Control port not input or output\n");
-					portsproblem=true;
+					fprintf (stderr, "Control port not input or output\n");
+					portsproblem = true;
 				}
-			} else if(lilv_port_is_a(plugin,porti,atom_AtomPort)) {
+			} else if (lilv_port_is_a (plugin, porti, atom_AtomPort)) {
 				/* OK, handled later */
-			} else if(!lilv_port_has_property(plugin,porti,optional)) {
-				fprintf(stderr,"Error!  Unable to handle a required port \n");
-				portsproblem=true;
+			} else if (!lilv_port_has_property (plugin, porti, optional)) {
+				fprintf (stderr, "Error!  Unable to handle a required port \n");
+				portsproblem = true;
 			}
 		}
 
-		if(portsproblem) {
+		if (portsproblem) {
 			goto cleanup_sndfile;
 		}
-		formatinfo.channels=numout;
-		SNDFILE* outsndfile=sf_open(*(outfile->filename), SFM_WRITE, &formatinfo);
+		formatinfo.channels = numout;
+		SNDFILE* outsndfile = sf_open (*(outfile->filename), SFM_WRITE, &formatinfo);
 
-		sndfileerr=sf_error(outsndfile) ;
-		if(sndfileerr) {
-			fprintf(stderr,"Error reading output file: %s\n",sf_error_number(sndfileerr));
+		sndfileerr = sf_error (outsndfile);
+		if (sndfileerr) {
+			fprintf (stderr, "Error reading output file: %s\n", sf_error_number (sndfileerr));
 			goto cleanup_outfile;
 		}
 
 		{
-			unsigned int numplugins=1;
-			if(connectargs->count) {
-				for(int i=0; i<connectargs->count; i++) {
-					const char * connectionlist=connectargs->sval[i];
-					while(*connectionlist) {
-						char* nextcomma=strchr(connectionlist,',');
+			unsigned int numplugins = 1;
+			if (connectargs->count) {
+				for (int i = 0; i < connectargs->count; i++) {
+					const char* connectionlist = connectargs->sval[i];
+					while (*connectionlist) {
+						char* nextcomma = strchr (connectionlist, ',');
 						char* nextcolon;
-						if(nextcomma) {
-							nextcolon=memchr(connectionlist,':',nextcomma-connectionlist);
+						if (nextcomma) {
+							nextcolon = memchr (connectionlist, ':', nextcomma - connectionlist);
 						} else {
-							nextcolon=strchr(connectionlist,':');
+							nextcolon = strchr (connectionlist, ':');
 						}
-						if(!nextcolon) {
-							fprintf(stderr, "Error parsing connection:  Expected colon between channel and port.\n");
+						if (!nextcolon) {
+							fprintf (stderr, "Error parsing connection:  Expected colon between channel and port.\n");
 							goto cleanup_outfile;
 						}
 						nextcolon++;
-						int pluginstance=0;
-						char* nextperiod=strchr(nextcolon,'.');
-						if(nextperiod) {
-							char tmpbuffer[nextperiod-nextcolon+1];
-							memcpy(tmpbuffer,nextcolon,sizeof(char)*(nextperiod-nextcolon));
-							tmpbuffer[nextperiod-nextcolon]=0;
-							pluginstance=atoi(tmpbuffer)-1;
-							if(pluginstance<0) {
-								fprintf(stderr, "Invalid plugin instance specified");
+						int   pluginstance = 0;
+						char* nextperiod   = strchr (nextcolon, '.');
+						if (nextperiod) {
+							char tmpbuffer[nextperiod - nextcolon + 1];
+							memcpy (tmpbuffer, nextcolon, sizeof (char) * (nextperiod - nextcolon));
+							tmpbuffer[nextperiod - nextcolon] = 0;
+							pluginstance                      = atoi (tmpbuffer) - 1;
+							if (pluginstance < 0) {
+								fprintf (stderr, "Invalid plugin instance specified");
 								goto cleanup_outfile;
 							}
 						} else {
-							nextperiod=nextcolon;
+							nextperiod = nextcolon;
 						}
-						if(((unsigned)pluginstance)>=numplugins) {
+						if (((unsigned)pluginstance) >= numplugins) {
 							//Make sure we are instantiating enough instances of the plugin.
-							numplugins=pluginstance+1;
+							numplugins = pluginstance + 1;
 						}
-						if(nextcomma) {
-							connectionlist=nextcomma+1;
+						if (nextcomma) {
+							connectionlist = nextcomma + 1;
 						} else {
 							break;
 						}
 					}
 				}
-			} else if(numin==1 && !mixdown) {
-				numplugins=numchannels;
+			} else if (numin == 1 && !mixdown) {
+				numplugins = numchannels;
 			}
-			printf("Note: Running %i instances of the plugin.\n",numplugins);
+			printf ("Note: Running %i instances of the plugin.\n", numplugins);
 			bool connections[numplugins][numin][numchannels];
-			memset(connections,0,sizeof(connections));
+			memset (connections, 0, sizeof (connections));
 
 			LilvInstance* instances[numplugins];
-			if(connectargs->count) {
-				for(int i=0; i<connectargs->count; i++) {
-					const char * connectionlist=connectargs->sval[i];
-					while(*connectionlist) {
-						int channel=atoi(connectionlist)-1;
-						if(channel<0|| ((unsigned)channel)>=numchannels) {
-							fprintf(stderr, "Input sound file does not have channel %u.  It has %u channels.\n",channel+1,numchannels);
+			if (connectargs->count) {
+				for (int i = 0; i < connectargs->count; i++) {
+					const char* connectionlist = connectargs->sval[i];
+					while (*connectionlist) {
+						int channel = atoi (connectionlist) - 1;
+						if (channel < 0 || ((unsigned)channel) >= numchannels) {
+							fprintf (stderr, "Input sound file does not have channel %u.  It has %u channels.\n", channel + 1, numchannels);
 							goto cleanup_outfile;
 						}
 
-						char* nextcomma=strchr(connectionlist,',');
-						if(nextcomma) {
-							*nextcomma=0;
+						char* nextcomma = strchr (connectionlist, ',');
+						if (nextcomma) {
+							*nextcomma = 0;
 						}
-						char* nextcolon=strchr(connectionlist,':');
+						char* nextcolon = strchr (connectionlist, ':');
 						//Will not be nill otherwise it would have been caught when counting plugin instances
-						*nextcolon=0;
+						*nextcolon = 0;
 						nextcolon++;
-						unsigned int pluginstance=0;
-						char* nextperiod=strchr(nextcolon,'.');
-						if(nextperiod) {
-							*nextperiod=0;
-							pluginstance=atoi(nextcolon+1)-1;
+						unsigned int pluginstance = 0;
+						char*        nextperiod   = strchr (nextcolon, '.');
+						if (nextperiod) {
+							*nextperiod  = 0;
+							pluginstance = atoi (nextcolon + 1) - 1;
 						} else {
-							nextperiod=nextcolon;
+							nextperiod = nextcolon;
 						}
-						bool foundmatch=false;
-						for(uint32_t port=0; port<numin; port++) {
+						bool foundmatch = false;
+						for (uint32_t port = 0; port < numin; port++) {
 							//Do not need to free, kept internally.
-							const char* symbol=lilv_node_as_string(lilv_port_get_symbol(plugin,lilv_plugin_get_port_by_index(plugin,inindices[port])));
-							if(!strcmp(symbol,nextperiod)) {
-								connections[pluginstance][port][channel]=true;
-								foundmatch=true;
+							const char* symbol = lilv_node_as_string (lilv_port_get_symbol (plugin, lilv_plugin_get_port_by_index (plugin, inindices[port])));
+							if (!strcmp (symbol, nextperiod)) {
+								connections[pluginstance][port][channel] = true;
+								foundmatch                               = true;
 								break;
 							}
 						}
-						if(!foundmatch) {
-							fprintf(stderr, "Port with symbol %s does not exist.\n",nextcolon);
+						if (!foundmatch) {
+							fprintf (stderr, "Port with symbol %s does not exist.\n", nextcolon);
 						}
-						if(nextcomma) {
-							connectionlist=nextcomma+1;
+						if (nextcomma) {
+							connectionlist = nextcomma + 1;
 						} else {
 							break;
 						}
 					}
 				}
-				printf("Note: Only making user specified connections.\n");
+				printf ("Note: Only making user specified connections.\n");
 			} else {
-				if(numin==numchannels) {
-					printf("Note: Mapping audio channels to plugin ports based on ordering\n");
-					for(unsigned int i=0; i<numin; i++) {
-						connections[0][i][i]=true;
+				if (numin == numchannels) {
+					printf ("Note: Mapping audio channels to plugin ports based on ordering\n");
+					for (unsigned int i = 0; i < numin; i++) {
+						connections[0][i][i] = true;
 					}
-				} else if(numin==1) {
-					if(mixdown) {
-						printf("Note: Down mixing all channels to a single plugin input\n");
-						for(unsigned int i=0; i<numin; i++) {
-							connections[0][0][i]=true;
+				} else if (numin == 1) {
+					if (mixdown) {
+						printf ("Note: Down mixing all channels to a single plugin input\n");
+						for (unsigned int i = 0; i < numin; i++) {
+							connections[0][0][i] = true;
 						}
 					} else {
-						printf("Note: Running an instance of the plugin per channel\n");
-						for(unsigned int i=0; i<numchannels; i++) {
-							connections[i][0][i]=true;
+						printf ("Note: Running an instance of the plugin per channel\n");
+						for (unsigned int i = 0; i < numchannels; i++) {
+							connections[i][0][i] = true;
 						}
 					}
-				}else if(numchannels>numin) {
-					printf("Note: Extra channels ignored when mapping channels to plugin ports\n");
-					for(unsigned int i=0; i<numin; i++) {
-						connections[0][i][i]=true;
+				} else if (numchannels > numin) {
+					printf ("Note: Extra channels ignored when mapping channels to plugin ports\n");
+					for (unsigned int i = 0; i < numin; i++) {
+						connections[0][i][i] = true;
 					}
 				} else {
-					fprintf(stderr,"Error: Not enough input channels to connect all of the plugin's ports.  Please manually specify connections\n");
+					fprintf (stderr, "Error: Not enough input channels to connect all of the plugin's ports.  Please manually specify connections\n");
 					goto cleanup_outfile;
 				}
 			}
@@ -666,33 +689,32 @@ int main(int argc, char** argv) {
 
 			float minvalues[numports];
 			float maxvalues[numports];
-			lilv_plugin_get_port_ranges_float(plugin,minvalues,maxvalues,defaultvalues);
+			lilv_plugin_get_port_ranges_float (plugin, minvalues, maxvalues, defaultvalues);
 
 			struct statehelper sh = { plugin, numports, defaultvalues };
 
-			bool has_worker = lilv_plugin_has_feature (plugin, worker_schedule) && lilv_plugin_has_extension_data(plugin, worker_iface_uri);
+			bool has_worker = lilv_plugin_has_feature (plugin, worker_schedule) && lilv_plugin_has_extension_data (plugin, worker_iface_uri);
 
-			LV2_URID atom_Int = uri_to_id(NULL, LV2_ATOM__Int);
+			LV2_URID           atom_Int  = uri_to_id (NULL, LV2_ATOM__Int);
 			LV2_Options_Option options[] = {
-				{ LV2_OPTIONS_INSTANCE, 0, uri_to_id(NULL, LV2_BUF_SIZE__minBlockLength),
-					sizeof(int32_t), atom_Int, &blocksize },
-				{ LV2_OPTIONS_INSTANCE, 0, uri_to_id(NULL, LV2_BUF_SIZE__maxBlockLength),
-					sizeof(int32_t), atom_Int, &blocksize },
-				{ LV2_OPTIONS_INSTANCE, 0, uri_to_id(NULL, LV2_BUF_SIZE__sequenceSize),
-					sizeof(int32_t), atom_Int, &atom_capacity },
-				{ LV2_OPTIONS_INSTANCE, 0, uri_to_id(NULL, "http://lv2plug.in/ns/ext/buf-size#nominalBlockLength"),
-					sizeof(int32_t), atom_Int, &blocksize },
+				{ LV2_OPTIONS_INSTANCE, 0, uri_to_id (NULL, LV2_BUF_SIZE__minBlockLength),
+				  sizeof (int32_t), atom_Int, &blocksize },
+				{ LV2_OPTIONS_INSTANCE, 0, uri_to_id (NULL, LV2_BUF_SIZE__maxBlockLength),
+				  sizeof (int32_t), atom_Int, &blocksize },
+				{ LV2_OPTIONS_INSTANCE, 0, uri_to_id (NULL, LV2_BUF_SIZE__sequenceSize),
+				  sizeof (int32_t), atom_Int, &atom_capacity },
+				{ LV2_OPTIONS_INSTANCE, 0, uri_to_id (NULL, "http://lv2plug.in/ns/ext/buf-size#nominalBlockLength"),
+				  sizeof (int32_t), atom_Int, &blocksize },
 				{ LV2_OPTIONS_INSTANCE, 0, 0, 0, 0, NULL }
 			};
 
-			LV2_URID_Map uri_map               = { NULL, &uri_to_id };
-			const LV2_Feature map_feature      = { LV2_URID__map, &uri_map};
-			const LV2_Feature unmap_feature    = { LV2_URID__unmap, NULL };
-			const LV2_Feature options_feature  = { LV2_OPTIONS__options, options};
+			LV2_URID_Map      uri_map         = { NULL, &uri_to_id };
+			const LV2_Feature map_feature     = { LV2_URID__map, &uri_map };
+			const LV2_Feature unmap_feature   = { LV2_URID__unmap, NULL };
+			const LV2_Feature options_feature = { LV2_OPTIONS__options, options };
 
-			for(unsigned int i=0; i<numplugins; i++) {
-
-				int n_features = 3;
+			for (unsigned int i = 0; i < numplugins; i++) {
+				int                n_features = 3;
 				const LV2_Feature* features[5];
 				features[0] = &map_feature;
 				features[1] = &unmap_feature;
@@ -700,12 +722,12 @@ int main(int argc, char** argv) {
 
 				LV2_Worker_Schedule* schedule = NULL;
 				if (has_worker) {
-					schedule = (LV2_Worker_Schedule*)malloc(sizeof(LV2_Worker_Schedule));
+					schedule                = (LV2_Worker_Schedule*)malloc (sizeof (LV2_Worker_Schedule));
 					schedule->handle        = NULL;
 					schedule->schedule_work = lv2_worker_schedule;
 
 					const LV2_Feature schedule_feature = { LV2_WORKER__schedule, schedule };
-					features[n_features++]  = &schedule_feature;
+					features[n_features++]             = &schedule_feature;
 				}
 
 				features[n_features] = NULL;
@@ -713,12 +735,12 @@ int main(int argc, char** argv) {
 				instances[i] = lilv_plugin_instantiate (plugin, formatinfo.samplerate, features);
 
 				if (!instances[i]) {
-					fprintf(stderr,"Failed to instantiate plugin!\n");
+					fprintf (stderr, "Failed to instantiate plugin!\n");
 					goto cleanup_outfile;
 				}
 
 				if (has_worker) {
-					worker_iface = (LV2_Worker_Interface*)lilv_instance_get_extension_data(instances[i], LV2_WORKER__interface);
+					worker_iface = (LV2_Worker_Interface*)lilv_instance_get_extension_data (instances[i], LV2_WORKER__interface);
 					// XXX store handle + iface per instance ?!
 					schedule->handle = instances[i]->lv2_handle;
 				}
@@ -727,61 +749,61 @@ int main(int argc, char** argv) {
 					lilv_state_restore (state, instances[i], set_port_value, &sh, 0, NULL);
 				}
 
-				lilv_instance_activate(instances[i]);
+				lilv_instance_activate (instances[i]);
 			}
-			lilv_state_free(state);
+			lilv_state_free (state);
 
 			{
 				float pluginbuffers[numplugins][numin][blocksize];
-				memset(pluginbuffers,0,sizeof(pluginbuffers));
+				memset (pluginbuffers, 0, sizeof (pluginbuffers));
 				float outputbuffers[numplugins][numout][blocksize];
-				memset(outputbuffers,0,sizeof(outputbuffers));
+				memset (outputbuffers, 0, sizeof (outputbuffers));
 
 				float controlports[numcontrol];
-				memset(controlports,0,sizeof(controlports));
+				memset (controlports, 0, sizeof (controlports));
 				float controloutports[numcontrolout];
 
-				for(unsigned int port=0; port<numcontrol; port++) {
-					unsigned int portindex=controlindices[port];
-					controlports[port]=getstartingvalue(defaultvalues[portindex],minvalues[portindex],maxvalues[portindex]);
+				for (unsigned int port = 0; port < numcontrol; port++) {
+					unsigned int portindex = controlindices[port];
+					controlports[port]     = getstartingvalue (defaultvalues[portindex], minvalues[portindex], maxvalues[portindex]);
 				}
 
 				if (fwheelportidx >= 0) {
 					controlports[fwheelportidx] = 1;
 				}
 
-				if(controls->count) {
-					for(int i=0; i<controls->count; i++) {
-						const char * parameters=controls->sval[i];
-						while(*parameters) {
-							char* nextcomma=strchr(parameters,',');
-							if(nextcomma) {
-								*nextcomma=0;
+				if (controls->count) {
+					for (int i = 0; i < controls->count; i++) {
+						const char* parameters = controls->sval[i];
+						while (*parameters) {
+							char* nextcomma = strchr (parameters, ',');
+							if (nextcomma) {
+								*nextcomma = 0;
 							}
-							char* nextcolon=strchr(parameters,':');
-							if(nextcolon) {
-								*nextcolon=0;
+							char* nextcolon = strchr (parameters, ':');
+							if (nextcolon) {
+								*nextcolon = 0;
 							} else {
-								fprintf(stderr, "Error parsing parameters:  Expected colon between port and value.\n");
+								fprintf (stderr, "Error parsing parameters:  Expected colon between port and value.\n");
 								goto cleanup_outfile;
 							}
 							nextcolon++;
-							float value=strtof(nextcolon,NULL);
-							bool foundmatch=false;
-							for(uint32_t port=0; port<numcontrol; port++) {
+							float value      = strtof (nextcolon, NULL);
+							bool  foundmatch = false;
+							for (uint32_t port = 0; port < numcontrol; port++) {
 								//Do not need to free, kept internally.
-								const char* symbol=lilv_node_as_string(lilv_port_get_symbol(plugin,lilv_plugin_get_port_by_index(plugin,controlindices[port])));
-								if(!strcmp(symbol,parameters)) {
-									controlports[port]=value;
-									foundmatch=true;
+								const char* symbol = lilv_node_as_string (lilv_port_get_symbol (plugin, lilv_plugin_get_port_by_index (plugin, controlindices[port])));
+								if (!strcmp (symbol, parameters)) {
+									controlports[port] = value;
+									foundmatch         = true;
 									break;
 								}
 							}
-							if(!foundmatch) {
-								fprintf(stderr, "WARNING: Port with symbol %s does not exist.\n",parameters);
+							if (!foundmatch) {
+								fprintf (stderr, "WARNING: Port with symbol %s does not exist.\n", parameters);
 							}
-							if(nextcomma) {
-								parameters=nextcomma+1;
+							if (nextcomma) {
+								parameters = nextcomma + 1;
 							} else {
 								break;
 							}
@@ -790,30 +812,31 @@ int main(int argc, char** argv) {
 				}
 
 				LV2_Atom_Sequence seq_in = {
-					{ sizeof(LV2_Atom_Sequence_Body),
-						uri_to_id(NULL, LV2_ATOM__Sequence) },
-					{ 0, 0 } };
+					{ sizeof (LV2_Atom_Sequence_Body),
+					  uri_to_id (NULL, LV2_ATOM__Sequence) },
+					{ 0, 0 }
+				};
 
-				LV2_Atom_Sequence* seq_out = (LV2_Atom_Sequence*)malloc(sizeof(LV2_Atom_Sequence) + atom_capacity);
+				LV2_Atom_Sequence* seq_out = (LV2_Atom_Sequence*)malloc (sizeof (LV2_Atom_Sequence) + atom_capacity);
 
-				for(unsigned int i=0; i<numplugins; i++) {
-					for(unsigned int port=0; port<numin; port++) {
-						lilv_instance_connect_port(instances[i],inindices[port],pluginbuffers[i][port]);
+				for (unsigned int i = 0; i < numplugins; i++) {
+					for (unsigned int port = 0; port < numin; port++) {
+						lilv_instance_connect_port (instances[i], inindices[port], pluginbuffers[i][port]);
 					}
-					for(unsigned int port=0; port<numout; port++) {
-						lilv_instance_connect_port(instances[i],outindices[port],outputbuffers[i][port]);
+					for (unsigned int port = 0; port < numout; port++) {
+						lilv_instance_connect_port (instances[i], outindices[port], outputbuffers[i][port]);
 					}
-					for(unsigned int port=0; port<numcontrol; port++) {
-						lilv_instance_connect_port(instances[i],controlindices[port],&controlports[port]);
+					for (unsigned int port = 0; port < numcontrol; port++) {
+						lilv_instance_connect_port (instances[i], controlindices[port], &controlports[port]);
 					}
-					for(unsigned int port=0; port<numcontrolout; port++) {
-						lilv_instance_connect_port(instances[i],controloutindices[port],&controloutports[port]);
+					for (unsigned int port = 0; port < numcontrolout; port++) {
+						lilv_instance_connect_port (instances[i], controloutindices[port], &controloutports[port]);
 					}
 
-					for(uint32_t j = 0; j < numports; j++) {
-						const LilvPort* porti = lilv_plugin_get_port_by_index(plugin, j);
-						if(lilv_port_is_a (plugin, porti, atom_AtomPort)) {
-							if(lilv_port_is_a(plugin, porti, input_class)) {
+					for (uint32_t j = 0; j < numports; j++) {
+						const LilvPort* porti = lilv_plugin_get_port_by_index (plugin, j);
+						if (lilv_port_is_a (plugin, porti, atom_AtomPort)) {
+							if (lilv_port_is_a (plugin, porti, input_class)) {
 								lilv_instance_connect_port (instances[i], j, &seq_in);
 							} else {
 								lilv_instance_connect_port (instances[i], j, seq_out);
@@ -821,55 +844,55 @@ int main(int argc, char** argv) {
 						}
 					}
 				}
-				if(ignore_clipping->count) {
-					process_no_check_clipping(blocksize, numchannels, numin, numout, numplugins, connections, pluginbuffers, outputbuffers, instances, &seq_in, seq_out, insndfile, outsndfile);
+				if (ignore_clipping->count) {
+					process_no_check_clipping (blocksize, numchannels, numin, numout, numplugins, connections, pluginbuffers, outputbuffers, instances, &seq_in, seq_out, insndfile, outsndfile);
 				} else {
-					process_check_clipping(blocksize, numchannels, numin, numout, numplugins, connections, pluginbuffers, outputbuffers, instances, &seq_in, seq_out, insndfile, outsndfile);
+					process_check_clipping (blocksize, numchannels, numin, numout, numplugins, connections, pluginbuffers, outputbuffers, instances, &seq_in, seq_out, insndfile, outsndfile);
 				}
 			}
 
 			//cleanup_lv2:
-				for(unsigned int i=0; i<numplugins; i++) {
-					lilv_instance_deactivate(instances[i]);
-					lilv_instance_free(instances[i]);
-				}
-		}
-		cleanup_outfile:
-			if(sf_close  (outsndfile)) {
-				fprintf(stderr,"Error closing output file!\n");
+			for (unsigned int i = 0; i < numplugins; i++) {
+				lilv_instance_deactivate (instances[i]);
+				lilv_instance_free (instances[i]);
 			}
+		}
+	cleanup_outfile:
+		if (sf_close (outsndfile)) {
+			fprintf (stderr, "Error closing output file!\n");
+		}
 	}
 
-	cleanup_sndfile:
-		if(sf_close  (insndfile)) {
-			fprintf(stderr,"Error closing input file!\n");
-		}
+cleanup_sndfile:
+	if (sf_close (insndfile)) {
+		fprintf (stderr, "Error closing input file!\n");
+	}
 
-	cleanup_lilvnodes:
-		lilv_node_free(input_class);
-		lilv_node_free(output_class);
-		lilv_node_free(control_class);
-		lilv_node_free(audio_class);
-		lilv_node_free(event_class);
-		lilv_node_free(midi_class);
-		lilv_node_free(preset_class);
-		lilv_node_free(optional);
-		lilv_node_free(freewheel_port);
-		lilv_node_free(latency_port);
-		lilv_node_free(label_pred);
-		lilv_node_free(atom_AtomPort);
-		lilv_node_free(atom_Sequence);
-		lilv_node_free(worker_schedule);
-		lilv_node_free(worker_iface_uri);
+cleanup_lilvnodes:
+	lilv_node_free (input_class);
+	lilv_node_free (output_class);
+	lilv_node_free (control_class);
+	lilv_node_free (audio_class);
+	lilv_node_free (event_class);
+	lilv_node_free (midi_class);
+	lilv_node_free (preset_class);
+	lilv_node_free (optional);
+	lilv_node_free (freewheel_port);
+	lilv_node_free (latency_port);
+	lilv_node_free (label_pred);
+	lilv_node_free (atom_AtomPort);
+	lilv_node_free (atom_Sequence);
+	lilv_node_free (worker_schedule);
+	lilv_node_free (worker_iface_uri);
 
-	cleanup_argtable:
-		arg_freetable(argtable,sizeof(argtable)/sizeof(argtable[0]));
-	cleanup_listnamestable:
-		arg_freetable(listnamestable,sizeof(listnamestable)/sizeof(listnamestable[0]));
-	cleanup_lilvworld:
-		lilv_world_free(lilvworld);
-	cleanup_listtable:
-		arg_freetable(listtable,sizeof(listtable)/sizeof(listtable[0]));
+cleanup_argtable:
+	arg_freetable (argtable, sizeof (argtable) / sizeof (argtable[0]));
+cleanup_listnamestable:
+	arg_freetable (listnamestable, sizeof (listnamestable) / sizeof (listnamestable[0]));
+cleanup_lilvworld:
+	lilv_world_free (lilvworld);
+cleanup_listtable:
+	arg_freetable (listtable, sizeof (listtable) / sizeof (listtable[0]));
 
 	free_uri_map ();
 }

--- a/lv2file.c
+++ b/lv2file.c
@@ -47,6 +47,7 @@ static char **urimap = NULL;
 static uint32_t urimap_len = 0;
 
 static uint32_t uri_to_id(LV2_URI_Map_Callback_Data unused, const char* uri) {
+  (void) unused;
   for (uint32_t i = 0; i < urimap_len; ++i) {
     if (!strcmp(urimap[i], uri)) {
       return i + 1;
@@ -94,7 +95,7 @@ lv2_worker_schedule(LV2_Worker_Schedule_Handle handle,
  */
 struct statehelper {
 	const LilvPlugin* plugin;
-	int               numports;
+	uint32_t          numports;
 	float*            params;
 };
 
@@ -108,6 +109,7 @@ set_port_value(const char* port_symbol,
 	if (type != 0 && type != uri_to_id(NULL, "http://lv2plug.in/ns/ext/atom#Float")) {
 		return;
 	}
+	(void) size; // unused
 	float val = *(const float*)value;
 	//printf ("STATE set %s to %f (t: %d)\n", port_symbol, val, type);
 	struct statehelper* sh = (struct statehelper*) user_data;

--- a/lv2file.c
+++ b/lv2file.c
@@ -260,9 +260,17 @@ void list_names(LilvWorld* lilvworld, const LilvPlugins* plugins, const char* pl
 	lilv_node_free(control_class);
 }
 
+/* TODO Notes:
+ * - properly zero (silence pad to blocksize) buffer at EOF
+ * - verify mix/interleave with replicated buffers (numplugins * numout == numchannels)
+ * - (do a latency compute run, set _plugin_latency_samples)
+ * - skip writing first _plugin_latency_samples to file
+ * - zero-pad _plugin_latency_samples input frames and keep processing
+ */
+
 /* X-Macro */
 #define DEFINE_PROCESS (unsigned int blocksize, unsigned int numchannels, unsigned int numin, unsigned int numout, unsigned int numplugins, bool connections[numplugins][numin][numchannels], float pluginbuffers[numplugins][numin][blocksize], float outputbuffers[numplugins][numout][blocksize],LilvInstance* instances[numplugins], LV2_Atom_Sequence* seq_in, LV2_Atom_Sequence* seq_out, SNDFILE* insndfile, SNDFILE* outsndfile){\
-	float sndfilebuffer[numout * blocksize];\
+	float sndfilebuffer[numplugins * numout * blocksize];\
 	float buffer[numchannels * blocksize];\
 	INITIALIZE_CLIPPED()\
 	sf_count_t numread;\


### PR DESCRIPTION
Motivated by https://github.com/lucianodato/noise-repellent/issues/56
Here is a patch-series to add various LV2 features.

The overall diff is rather large, because I took the liberty to also clean up the source-code. You may or may not want to skip merging the last two commits.

Also the original project has inconsistent licensing  (see https://github.com/jeremysalwen/lv2file/issues/2), I've cleaned this up as GPLv3+. Let me know what you think.